### PR TITLE
Fix CSS import order for build

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,12 +1,12 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
-/* One-Weekend Websites Design System - Modern, professional with human elements 
+/* One-Weekend Websites Design System - Modern, professional with human elements
 All colors MUST be HSL.
 */
-
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap');
 
 @layer base {
   :root {


### PR DESCRIPTION
## Summary
- move Google Fonts import before Tailwind directives in `index.css`

## Testing
- `npm run build`
- `npm run lint` *(fails: react-refresh and eslint no-empty-object-type issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c10cc95cec8331b2d7de07b883d567