### PR TITLE
style: enhance hero CTA visibility

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -30,8 +30,8 @@ const Hero = () => {
             </p>
             
             <div className="flex flex-col sm:flex-row gap-4 mb-8">
-              <Button 
-                className="btn-accent" 
+              <Button
+                className="btn-hero-cta"
                 size="lg"
                 onClick={() => window.open('https://cal.com/jordanlander/fit-check-15', '_blank')}
               >

--- a/src/index.css
+++ b/src/index.css
@@ -154,6 +154,16 @@ All colors MUST be HSL.
     @apply transition-all duration-300;
     @apply transform hover:scale-105;
   }
+
+  .btn-hero-cta {
+    @apply bg-primary text-primary-foreground hover:bg-primary-light;
+    @apply border-2 border-white;
+    @apply px-8 py-4 rounded-xl font-semibold text-lg;
+    @apply shadow-lg hover:shadow-xl;
+    @apply transition-all duration-300;
+    @apply transform hover:scale-105;
+    @apply animate-pulse;
+  }
   
   .btn-hero-outline {
     @apply border-2 border-primary text-primary hover:bg-primary hover:text-primary-foreground;


### PR DESCRIPTION
## Summary
- add dedicated `btn-hero-cta` style with white border and pulse animation
- apply new style to hero's "Book Free 15-min Fit Check" button for better contrast

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1e208e8cc8331a1a6759d50d4fd17