### PR TITLE
Add aria-hidden to decorative icons

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -17,7 +17,7 @@ const About = () => {
         <div className="grid md:grid-cols-3 gap-8 mb-16">
           <div className="text-center animate-slide-up">
             <div className="w-16 h-16 bg-primary text-primary-foreground rounded-2xl flex items-center justify-center mx-auto mb-4">
-              <Zap className="h-8 w-8" />
+              <Zap aria-hidden="true" className="h-8 w-8" />
             </div>
             <h3 className="text-xl font-semibold mb-3">Lightning Fast</h3>
             <p className="text-muted-foreground">
@@ -28,7 +28,7 @@ const About = () => {
           
           <div className="text-center animate-slide-up" style={{ animationDelay: '0.1s' }}>
             <div className="w-16 h-16 bg-accent text-accent-foreground rounded-2xl flex items-center justify-center mx-auto mb-4">
-              <Award className="h-8 w-8" />
+              <Award aria-hidden="true" className="h-8 w-8" />
             </div>
             <h3 className="text-xl font-semibold mb-3">Proven Results</h3>
             <p className="text-muted-foreground">
@@ -39,7 +39,7 @@ const About = () => {
           
           <div className="text-center animate-slide-up" style={{ animationDelay: '0.2s' }}>
             <div className="w-16 h-16 bg-primary text-primary-foreground rounded-2xl flex items-center justify-center mx-auto mb-4">
-              <Users className="h-8 w-8" />
+              <Users aria-hidden="true" className="h-8 w-8" />
             </div>
             <h3 className="text-xl font-semibold mb-3">Local Focus</h3>
             <p className="text-muted-foreground">

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -64,7 +64,7 @@ const Contact = () => {
             <div className="space-y-6 mb-8">
               <div className="flex items-center gap-4">
                 <div className="w-12 h-12 bg-primary text-primary-foreground rounded-xl flex items-center justify-center">
-                  <Phone className="h-6 w-6" />
+                  <Phone aria-hidden="true" className="h-6 w-6" />
                 </div>
                 <div>
                   <div className="font-semibold">Phone</div>
@@ -76,7 +76,7 @@ const Contact = () => {
               
               <div className="flex items-center gap-4">
                 <div className="w-12 h-12 bg-accent text-accent-foreground rounded-xl flex items-center justify-center">
-                  <Mail className="h-6 w-6" />
+                  <Mail aria-hidden="true" className="h-6 w-6" />
                 </div>
                 <div>
                   <div className="font-semibold">Email</div>
@@ -88,7 +88,7 @@ const Contact = () => {
               
               <div className="flex items-center gap-4">
                 <div className="w-12 h-12 bg-primary text-primary-foreground rounded-xl flex items-center justify-center">
-                  <MapPin className="h-6 w-6" />
+                  <MapPin aria-hidden="true" className="h-6 w-6" />
                 </div>
                 <div>
                   <div className="font-semibold">Location</div>
@@ -125,7 +125,7 @@ const Contact = () => {
                     className="w-10 h-10 bg-primary/10 hover:bg-primary/20 rounded-xl flex items-center justify-center transition-colors"
                     aria-label="Follow us on Facebook"
                   >
-                    <Facebook className="h-5 w-5 text-primary" />
+                    <Facebook aria-hidden="true" className="h-5 w-5 text-primary" />
                   </a>
                   <a 
                     href="https://nextdoor.com/pages/one-weekend-websites-lake-city-pa/" 
@@ -134,7 +134,7 @@ const Contact = () => {
                     className="w-10 h-10 bg-primary/10 hover:bg-primary/20 rounded-xl flex items-center justify-center transition-colors"
                     aria-label="Follow us on Nextdoor"
                   >
-                    <Home className="h-5 w-5 text-primary" />
+                    <Home aria-hidden="true" className="h-5 w-5 text-primary" />
                   </a>
                   <a 
                     href="https://www.linkedin.com/company/oneweekendwebsites/" 
@@ -143,7 +143,7 @@ const Contact = () => {
                     className="w-10 h-10 bg-primary/10 hover:bg-primary/20 rounded-xl flex items-center justify-center transition-colors"
                     aria-label="Follow us on LinkedIn"
                   >
-                    <Linkedin className="h-5 w-5 text-primary" />
+                    <Linkedin aria-hidden="true" className="h-5 w-5 text-primary" />
                   </a>
                   <a 
                     href="https://share.google/yyFsQaHPgPrCvrnPb" 
@@ -152,7 +152,7 @@ const Contact = () => {
                     className="w-10 h-10 bg-primary/10 hover:bg-primary/20 rounded-xl flex items-center justify-center transition-colors"
                     aria-label="View our Google Business Profile"
                   >
-                    <Building2 className="h-5 w-5 text-primary" />
+                    <Building2 aria-hidden="true" className="h-5 w-5 text-primary" />
                   </a>
                 </div>
               </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -43,7 +43,7 @@ const Footer = () => {
                   className="w-10 h-10 bg-background/10 hover:bg-background/20 rounded-xl flex items-center justify-center transition-colors"
                   aria-label="Follow us on Facebook"
                 >
-                  <Facebook className="h-5 w-5 text-background" />
+                  <Facebook aria-hidden="true" className="h-5 w-5 text-background" />
                 </a>
                 <a 
                   href="https://nextdoor.com/pages/one-weekend-websites-lake-city-pa/" 
@@ -52,7 +52,7 @@ const Footer = () => {
                   className="w-10 h-10 bg-background/10 hover:bg-background/20 rounded-xl flex items-center justify-center transition-colors"
                   aria-label="Follow us on Nextdoor"
                 >
-                  <Home className="h-5 w-5 text-background" />
+                  <Home aria-hidden="true" className="h-5 w-5 text-background" />
                 </a>
                 <a 
                   href="https://www.linkedin.com/company/oneweekendwebsites/" 
@@ -61,7 +61,7 @@ const Footer = () => {
                   className="w-10 h-10 bg-background/10 hover:bg-background/20 rounded-xl flex items-center justify-center transition-colors"
                   aria-label="Follow us on LinkedIn"
                 >
-                  <Linkedin className="h-5 w-5 text-background" />
+                  <Linkedin aria-hidden="true" className="h-5 w-5 text-background" />
                 </a>
                 <a 
                   href="https://share.google/yyFsQaHPgPrCvrnPb" 
@@ -70,7 +70,7 @@ const Footer = () => {
                   className="w-10 h-10 bg-background/10 hover:bg-background/20 rounded-xl flex items-center justify-center transition-colors"
                   aria-label="View our Google Business Profile"
                 >
-                  <Building2 className="h-5 w-5 text-background" />
+                  <Building2 aria-hidden="true" className="h-5 w-5 text-background" />
                 </a>
               </div>
             </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -90,7 +90,7 @@ const Header = () => {
               href="tel:18145808040"
               className="flex items-center text-primary hover:text-primary-light transition-colors"
             >
-              <Phone className="h-4 w-4 mr-1" />
+              <Phone aria-hidden="true" className="h-4 w-4 mr-1" />
               (814) 580-8040
             </a>
             <Button 
@@ -105,8 +105,9 @@ const Header = () => {
           <button
             className="md:hidden p-2"
             onClick={() => setIsMenuOpen(!isMenuOpen)}
+            aria-label={isMenuOpen ? 'Close menu' : 'Open menu'}
           >
-            {isMenuOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
+            {isMenuOpen ? <X aria-hidden="true" className="h-6 w-6" /> : <Menu aria-hidden="true" className="h-6 w-6" />}
           </button>
         </div>
         
@@ -156,7 +157,7 @@ const Header = () => {
                   href="tel:18145808040"
                   className="flex items-center text-primary hover:text-primary-light transition-colors"
                 >
-                  <Phone className="h-4 w-4 mr-1" />
+                  <Phone aria-hidden="true" className="h-4 w-4 mr-1" />
                   (814) 580-8040
                 </a>
                 <Button 

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -13,7 +13,7 @@ const Hero = () => {
           <div className="animate-fade-in">
             <div className="flex items-center gap-2 mb-6">
               <div className="w-12 h-12 bg-accent rounded-full flex items-center justify-center">
-                <Clock className="h-6 w-6 text-accent-foreground" />
+                <Clock aria-hidden="true" className="h-6 w-6 text-accent-foreground" />
               </div>
               <div>
                 <span className="text-accent font-semibold text-lg">One Weekend. One Website.</span>
@@ -37,7 +37,7 @@ const Hero = () => {
               >
                 <Link to="/book">
                   Book Free 15-min Fit Check
-                  <ArrowRight className="ml-2 h-5 w-5" />
+                  <ArrowRight aria-hidden="true" className="ml-2 h-5 w-5" />
                 </Link>
               </Button>
               <Button 
@@ -58,7 +58,7 @@ const Hero = () => {
                     className="text-white/80 hover:text-white text-sm p-0 h-auto font-normal"
                   >
                     More options
-                    <ChevronDown className="ml-1 h-4 w-4" />
+                    <ChevronDown aria-hidden="true" className="ml-1 h-4 w-4" />
                   </Button>
                 </PopoverTrigger>
                 <PopoverContent className="w-64 bg-popover/95 backdrop-blur-sm border-white/20">
@@ -88,7 +88,7 @@ const Hero = () => {
             
             <div className="flex flex-wrap items-center gap-4 text-sm text-white/80">
               <div className="flex items-center gap-2">
-                <DollarSign className="h-4 w-4" />
+                <DollarSign aria-hidden="true" className="h-4 w-4" />
                 <span>$499 flat</span>
               </div>
               <div className="flex items-center gap-2">
@@ -96,7 +96,7 @@ const Hero = () => {
                 <span>You own it</span>
               </div>
               <div className="flex items-center gap-2">
-                <Clock className="h-4 w-4" />
+                <Clock aria-hidden="true" className="h-4 w-4" />
                 <span>Launch in 48 hrs</span>
               </div>
             </div>

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -63,7 +63,7 @@ const projects = [
                   {project.category}
                 </div>
                 <div className="absolute top-4 right-4 bg-white/90 text-primary px-3 py-1 rounded-full text-sm font-medium flex items-center gap-1">
-                  <Calendar className="h-3 w-3" />
+                  <Calendar aria-hidden="true" className="h-3 w-3" />
                   {project.deliveryTime}
                 </div>
               </div>
@@ -82,7 +82,7 @@ const projects = [
                   className="w-full"
                   onClick={() => window.open(`https://${project.website}`, '_blank')}
                 >
-                  <ExternalLink className="mr-2 h-4 w-4" />
+                  <ExternalLink aria-hidden="true" className="mr-2 h-4 w-4" />
                   View Live Site
                 </Button>
               </div>
@@ -99,7 +99,7 @@ const projects = [
               {/* Barbers & salons */}
               <div className="bg-background rounded-xl border p-5 hover:shadow-md transition-shadow">
                 <div className="flex items-center gap-2 text-foreground mb-3">
-                  <Scissors className="h-5 w-5 text-primary" />
+                  <Scissors aria-hidden="true" className="h-5 w-5 text-primary" />
                   <h4 className="font-semibold">Barbers & salons</h4>
                 </div>
                 <p className="text-sm text-muted-foreground mb-3">Tap-to-book and map reviews from a single, fast page.</p>
@@ -112,7 +112,7 @@ const projects = [
               {/* Thrift & vintage */}
               <div className="bg-background rounded-xl border p-5 hover:shadow-md transition-shadow">
                 <div className="flex items-center gap-2 text-foreground mb-3">
-                  <ShoppingBag className="h-5 w-5 text-primary" />
+                  <ShoppingBag aria-hidden="true" className="h-5 w-5 text-primary" />
                   <h4 className="font-semibold">Thrift & vintage shops</h4>
                 </div>
                 <p className="text-sm text-muted-foreground mb-3">Show today's finds. Drive foot traffic—not just likes.</p>
@@ -125,7 +125,7 @@ const projects = [
               {/* Lawn care & landscaping */}
               <div className="bg-background rounded-xl border p-5 hover:shadow-md transition-shadow">
                 <div className="flex items-center gap-2 text-foreground mb-3">
-                  <Leaf className="h-5 w-5 text-primary" />
+                  <Leaf aria-hidden="true" className="h-5 w-5 text-primary" />
                   <h4 className="font-semibold">Lawn care & landscaping</h4>
                 </div>
                 <p className="text-sm text-muted-foreground mb-3">Quote requests that include address, lawn size, and photos.</p>
@@ -138,7 +138,7 @@ const projects = [
               {/* Churches & boosters */}
               <div className="bg-background rounded-xl border p-5 hover:shadow-md transition-shadow">
                 <div className="flex items-center gap-2 text-foreground mb-3">
-                  <Church className="h-5 w-5 text-primary" />
+                  <Church aria-hidden="true" className="h-5 w-5 text-primary" />
                   <h4 className="font-semibold">Churches & boosters</h4>
                 </div>
                 <p className="text-sm text-muted-foreground mb-3">Sign-ups, donations, and event info in one simple page.</p>
@@ -151,7 +151,7 @@ const projects = [
               {/* Etsy & makers */}
               <div className="bg-background rounded-xl border p-5 hover:shadow-md transition-shadow">
                 <div className="flex items-center gap-2 text-foreground mb-3">
-                  <Palette className="h-5 w-5 text-primary" />
+                  <Palette aria-hidden="true" className="h-5 w-5 text-primary" />
                   <h4 className="font-semibold">Etsy & makers</h4>
                 </div>
                 <p className="text-sm text-muted-foreground mb-3">A legit home base that links out to your shop and socials.</p>
@@ -164,7 +164,7 @@ const projects = [
               {/* Local services */}
               <div className="bg-background rounded-xl border p-5 hover:shadow-md transition-shadow">
                 <div className="flex items-center gap-2 text-foreground mb-3">
-                  <MapPin className="h-5 w-5 text-primary" />
+                  <MapPin aria-hidden="true" className="h-5 w-5 text-primary" />
                   <h4 className="font-semibold">Local services</h4>
                 </div>
                 <p className="text-sm text-muted-foreground mb-3">Calls, quotes, and directions without the platform lock-in.</p>

--- a/src/components/Pricing.tsx
+++ b/src/components/Pricing.tsx
@@ -20,7 +20,7 @@ const Pricing = () => {
           <div className="bg-card-gradient rounded-3xl p-8 shadow-lg border-2 border-primary/20 animate-slide-up">
             <div className="text-center mb-6">
               <div className="w-16 h-16 bg-primary text-primary-foreground rounded-2xl flex items-center justify-center mx-auto mb-4">
-                <DollarSign className="h-8 w-8" />
+                <DollarSign aria-hidden="true" className="h-8 w-8" />
               </div>
               <h3 className="text-2xl font-bold mb-2">Complete One-Page Website</h3>
               <div className="text-4xl font-bold text-primary mb-2">$499</div>
@@ -29,30 +29,30 @@ const Pricing = () => {
             
             <div className="space-y-3 mb-8">
               <div className="flex items-start gap-3">
-                <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <CheckCircle aria-hidden="true" className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
                 <span>Mobile-first design</span>
               </div>
               <div className="flex items-start gap-3">
-                <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <CheckCircle aria-hidden="true" className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
                 <span>Copy polish & CTA</span>
               </div>
               <div className="flex items-start gap-3">
-                <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <CheckCircle aria-hidden="true" className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
                 <span>Domain & Google indexing</span>
               </div>
               <div className="flex items-start gap-3">
-                <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <CheckCircle aria-hidden="true" className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
                 <span>2 image swaps</span>
               </div>
               <div className="flex items-start gap-3">
-                <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <CheckCircle aria-hidden="true" className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
                 <span>No monthly fees</span>
               </div>
             </div>
             
             <div className="bg-accent/10 p-4 rounded-lg mb-6">
               <div className="flex items-center gap-2 mb-2">
-                <Shield className="h-4 w-4 text-accent" />
+                <Shield aria-hidden="true" className="h-4 w-4 text-accent" />
                 <span className="font-semibold text-accent">Guarantee</span>
               </div>
               <p className="text-sm">20% off remaining balance if I miss the launch window.</p>
@@ -92,19 +92,19 @@ const Pricing = () => {
             
             <div className="space-y-3 mb-8">
               <div className="flex items-start gap-3">
-                <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <CheckCircle aria-hidden="true" className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
                 <span>DNS/HTTPS stewardship</span>
               </div>
               <div className="flex items-start gap-3">
-                <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <CheckCircle aria-hidden="true" className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
                 <span>Uptime watch</span>
               </div>
               <div className="flex items-start gap-3">
-                <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <CheckCircle aria-hidden="true" className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
                 <span>Monthly check-ins</span>
               </div>
               <div className="flex items-start gap-3">
-                <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <CheckCircle aria-hidden="true" className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
                 <span>30 min/month content updates</span>
               </div>
             </div>

--- a/src/components/Process.tsx
+++ b/src/components/Process.tsx
@@ -46,7 +46,7 @@ const Process = () => {
               >
                 <div className="relative mb-6">
                   <div className="w-16 h-16 bg-primary text-primary-foreground rounded-2xl flex items-center justify-center mx-auto shadow-lg">
-                    <IconComponent className="h-8 w-8" />
+                    <IconComponent aria-hidden="true" className="h-8 w-8" />
                   </div>
                   <div className="absolute -top-2 -right-2 bg-accent text-accent-foreground text-xs font-bold px-2 py-1 rounded-full">
                     {step.timeline}
@@ -66,28 +66,28 @@ const Process = () => {
             <div className="grid md:grid-cols-2 gap-6">
               <div className="space-y-4">
                 <div className="flex items-start gap-3">
-                  <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                  <CheckCircle aria-hidden="true" className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
                   <div>
                     <div className="font-medium">Mobile-First Design</div>
                     <div className="text-sm text-muted-foreground">Looks perfect on all devices</div>
                   </div>
                 </div>
                 <div className="flex items-start gap-3">
-                  <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                  <CheckCircle aria-hidden="true" className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
                   <div>
                     <div className="font-medium">Google-Ready SEO</div>
                     <div className="text-sm text-muted-foreground">Optimized to be found online</div>
                   </div>
                 </div>
                 <div className="flex items-start gap-3">
-                  <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                  <CheckCircle aria-hidden="true" className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
                   <div>
                     <div className="font-medium">Contact Forms</div>
                     <div className="text-sm text-muted-foreground">Lead generation that works</div>
                   </div>
                 </div>
                 <div className="flex items-start gap-3">
-                  <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                  <CheckCircle aria-hidden="true" className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
                   <div>
                     <div className="font-medium">Social Media Integration</div>
                     <div className="text-sm text-muted-foreground">Connect all your profiles</div>
@@ -97,28 +97,28 @@ const Process = () => {
               
               <div className="space-y-4">
                 <div className="flex items-start gap-3">
-                  <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                  <CheckCircle aria-hidden="true" className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
                   <div>
                     <div className="font-medium">Hosting Setup</div>
                     <div className="text-sm text-muted-foreground">Fast, reliable hosting included</div>
                   </div>
                 </div>
                 <div className="flex items-start gap-3">
-                  <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                  <CheckCircle aria-hidden="true" className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
                   <div>
                     <div className="font-medium">Full Ownership</div>
                     <div className="text-sm text-muted-foreground">You own everything, no lock-in</div>
                   </div>
                 </div>
                 <div className="flex items-start gap-3">
-                  <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                  <CheckCircle aria-hidden="true" className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
                   <div>
                     <div className="font-medium">30-Day Support</div>
                     <div className="text-sm text-muted-foreground">Help with any questions</div>
                   </div>
                 </div>
                 <div className="flex items-start gap-3">
-                  <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                  <CheckCircle aria-hidden="true" className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
                   <div>
                     <div className="font-medium">Google My Business</div>
                     <div className="text-sm text-muted-foreground">Local search optimization</div>

--- a/src/components/Testimonials.tsx
+++ b/src/components/Testimonials.tsx
@@ -50,12 +50,12 @@ const Testimonials = () => {
             >
               <div className="flex items-center gap-1 mb-4">
                 {[...Array(testimonial.rating)].map((_, i) => (
-                  <Star key={i} className="h-5 w-5 fill-yellow-400 text-yellow-400" />
+                  <Star aria-hidden="true" key={i} className="h-5 w-5 fill-yellow-400 text-yellow-400" />
                 ))}
               </div>
               
               <div className="relative mb-6">
-                <Quote className="h-8 w-8 text-primary/20 absolute -top-2 -left-2" />
+                <Quote aria-hidden="true" className="h-8 w-8 text-primary/20 absolute -top-2 -left-2" />
                 <p className="text-muted-foreground italic relative z-10 pl-6">
                   "{testimonial.text}"
                 </p>


### PR DESCRIPTION
## Summary
- hide decorative lucide-react icons from assistive tech across site sections
- label mobile menu toggle for screen readers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in src/pages/BlogPost.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c724c297e4833196b647c6ab9eb714