### PR TITLE
Fix mobile hamburger menu

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -163,8 +163,11 @@ All colors MUST be HSL.
   button, .btn, .cta { max-width: 100%; }
 
   /* off-canvas menu */
-  .nav-drawer, .mobile-menu {
-    position: fixed; top: 0; right: 0; bottom: 0;
+  .nav-drawer {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
     width: min(85dvw, 360px);        /* not 100vw */
     transform: translateX(100%);     /* closed */
   }


### PR DESCRIPTION
## Summary
- show mobile navigation by removing off-canvas transform from menu styles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c726cca6a48331bb4043eefe17633a